### PR TITLE
:hammer: Permissioned File Writing Fix :hammer: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Update or revert to a specific [Foundry](https://github.com/gakonst/foundry) com
 
 ```sh
 curl https://raw.githubusercontent.com/transmissions11/forgeup/main/install | bash
-source $HOME/.profile # source the profile to add the alias
+source $HOME/.profile # Register the forgeup alias in the current session.
 ```
 
 ## Using

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Update or revert to a specific [Foundry](https://github.com/gakonst/foundry) com
 
 ```sh
 curl https://raw.githubusercontent.com/transmissions11/forgeup/main/install | bash
-source $HOME:/.profile # source the profile to add the alias
+source $HOME/.profile # source the profile to add the alias
 ```
 
 ## Using

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Update or revert to a specific [Foundry](https://github.com/gakonst/foundry) com
 
 ```sh
 curl https://raw.githubusercontent.com/transmissions11/forgeup/main/install | bash
+source $HOME:/.profile # source the profile to add the alias
 ```
 
 ## Using

--- a/install
+++ b/install
@@ -55,8 +55,8 @@ FORGE_DIR="$HOME/.forgeup"
 BINARY="$FORGE_DIR/forgeup"
 
 # Create the .forgeup directory and binary file if it doesn't exist
-mkdir -p $FORGE_DIR >/dev/null
-touch $BINARY >/dev/null
+mkdir -p $FORGE_DIR
+touch $BINARY
 echo "$FORGEUP" > $BINARY
 chmod +x $BINARY
 

--- a/install
+++ b/install
@@ -61,7 +61,7 @@ echo "$FORGEUP" | tee "$BINARY" >/dev/null
 chmod +x $BINARY
 
 # Add the forge directory to the path and source it
-echo "export PATH=$PATH:$FORGE_DIR" | tee -a ~/.profile >/dev/null
+echo "export PATH=$PATH:$FORGE_DIR" | tee -a $HOME/.profile >/dev/null
 
 # Source the updated profile
-source ~/.profile
+source $HOME/.profile

--- a/install
+++ b/install
@@ -60,7 +60,7 @@ touch $BINARY
 echo "$FORGEUP" > $BINARY
 chmod +x $BINARY
 
-# Source the updated profile
+# Source the profile to make sure we have an up-to-date PATH
 source $HOME/.profile
 
 # Only add the forgeup directory to profile if it isn't in path

--- a/install
+++ b/install
@@ -56,7 +56,6 @@ BINARY="$FORGE_DIR/forgeup"
 
 # Create the .forgeup directory and binary file if it doesn't exist
 mkdir -p $FORGE_DIR
-touch $BINARY
 echo "$FORGEUP" > $BINARY
 chmod +x $BINARY
 

--- a/install
+++ b/install
@@ -60,8 +60,14 @@ touch $BINARY >/dev/null
 echo "$FORGEUP" > $BINARY
 chmod +x $BINARY
 
-# Add the forge directory to the path and source it
-echo "export PATH=$PATH:$FORGE_DIR" | tee -a $HOME/.profile >/dev/null
+# Source the updated profile
+source $HOME/.profile
+
+# Only add the forgeup directory to profile if it isn't in path
+if [[ ":$PATH:" != *":$HOME/.forgeup:"* ]]; then
+    # Add the forgeup directory to the path and source it
+    echo "export PATH=$PATH:$FORGE_DIR" >> $HOME/.profile
+fi
 
 # Source the updated profile
 source $HOME/.profile

--- a/install
+++ b/install
@@ -57,7 +57,7 @@ BINARY="$FORGE_DIR/forgeup"
 # Create the .forgeup directory and binary file if it doesn't exist
 mkdir -p $FORGE_DIR >/dev/null
 touch $BINARY >/dev/null
-echo "$FORGEUP" | tee "$BINARY" >/dev/null
+echo "$FORGEUP" > $BINARY
 chmod +x $BINARY
 
 # Add the forge directory to the path and source it

--- a/install
+++ b/install
@@ -50,6 +50,18 @@ else
     cargo install --path ./cli --bins --locked --force
 fi'
 
-BINARY="/usr/local/bin/forgeup"
-echo "$FORGEUP" | tee $BINARY >/dev/null
+# Directory config
+FORGE_DIR="$HOME/.forgeup"
+BINARY="$FORGE_DIR/forgeup"
+
+# Create the .forgeup directory and binary file if it doesn't exist
+mkdir -p $FORGE_DIR >/dev/null
+touch $BINARY >/dev/null
+echo "$FORGEUP" | tee "$BINARY" >/dev/null
 chmod +x $BINARY
+
+# Add the forge directory to the path and source it
+echo "export PATH=$PATH:$FORGE_DIR" | tee -a ~/.profile >/dev/null
+
+# Source the updated profile
+source ~/.profile

--- a/install
+++ b/install
@@ -51,5 +51,5 @@ else
 fi'
 
 BINARY="/usr/local/bin/forgeup"
-echo "$FORGEUP" > $BINARY
+echo "$FORGEUP" | tee $BINARY >/dev/null
 chmod +x $BINARY


### PR DESCRIPTION
## The Issue

When redirecting an echo, the output `sudo` privileges are lost and the command fails to append to the file. Thus, even when running the script with super user permissions, the redirect happens before the shell starts so permissions are not given to append to a file. See an example on Ubuntu 20.04.3 LTS below

![Screenshot from 2022-01-13 13-56-53](https://user-images.githubusercontent.com/21288394/149394367-13c11a90-bc0f-4ffd-8303-b6bf1d7669ba.png)


## Solution

We can use `tee` and a pipe to synchronize the permissions like so:   

**Before**

![Screenshot from 2022-01-13 13-53-22](https://user-images.githubusercontent.com/21288394/149394401-f0b9f4e9-a43b-466b-84d5-456194f3844f.png)


**After**

![Screenshot from 2022-01-13 14-07-09](https://user-images.githubusercontent.com/21288394/149394282-2386ff82-b2d0-4417-b1b8-5de1c2816631.png)

## Background

- [Solving Permission denied error when trying to echo into a file](https://techoverflow.net/2019/03/16/how-to-solve-permission-denied-error-when-trying-to-echo-into-a-file/)
- [Can't echo into file](https://askubuntu.com/questions/103643/cannot-echo-hello-x-txt-even-with-sudo)