### PR TITLE
checkout -> pull

### DIFF
--- a/install
+++ b/install
@@ -35,8 +35,8 @@ mkdir -p $FOUNDRY_PATH
 if [ -d $REPO_PATH ]
 then
     cd $REPO_PATH
-    git pull
     git checkout ${BRANCH}
+    git pull
     cargo install --path ./cli --bins --locked --force
 else
     # repo path didnt exist, grab the author from the repo,


### PR DESCRIPTION
When doing some branch things ran into:
```
Your configuration specifies to merge with the ref 'refs/heads/parallel-tests'
from the remote, but no such ref was fetched.
```

I believe this should fix it, by checking out the branch first then pulling.

Current way works well enough i doubt anyone will need to upgrade for this fix but if anyone complains we can tell them to update