### PR TITLE
Add shell detection support and exit if cargo not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Update or revert to a specific [Foundry](https://github.com/gakonst/foundry) com
 
 ```sh
 curl https://raw.githubusercontent.com/transmissions11/forgeup/main/install | bash
-source $HOME/.profile # Register the forgeup alias in the current session.
 ```
 
 ## Using

--- a/install
+++ b/install
@@ -14,6 +14,12 @@ GREEN="\033[0;32m"
 RED="\033[0;31m"
 NC="\033[0m"
 
+if ! command -v cargo &> /dev/null
+then
+    echo -e ${RED}Error: ${GREEN}you do not have ${RED}cargo${GREEN}, please install it before using ${RED}forgeup${GREEN}!${NC}
+    exit
+fi
+
 if [[ "$1" == *foundry* || "$1" == *dapptools-rs*  ]]
 then
     REPO=$1
@@ -63,16 +69,17 @@ chmod +x $BINARY
 # Store the correct profile file (e.g. .profile for bash or .zshrc for ZSH)
 case $SHELL in
 */zsh) 
-   echo "Detected your preferred shell is ZSH, adding forgeup to '.zshrc'. Please run 'source ~/.zshrc' after this script runs, or start a new terminal session to use forgeup."
-   PROFILE=$HOME/.zshrc
-   ;;
+    echo -e ${GREEN}Detected your preferred shell is ${RED}zsh${GREEN}, adding ${RED}forgeup${GREEN} to ${RED}.zshrc${GREEN}. Please run ${RED}source \~/.zshrc${GREEN} after this script runs, or start a new terminal session to use ${RED}forgeup${GREEN}.${NC}
+    PROFILE=$HOME/.zshrc
+    ;;
 */bash)
-   PROFILE=$HOME/.profile
-   source $PROFILE
-   ;;
+    echo -e ${GREEN}Detected your preferred shell is ${RED}bash${GREEN}, adding ${RED}forgeup${GREEN} to ${RED}.profile${GREEN}.
+    PROFILE=$HOME/.profile
+    source $PROFILE
+    ;;
 *)
-   echo "Error: could not detect shell, please manually add $FORGE_DIR to your PATH variable!"
-   exit 1
+    echo -e ${RED}Error: ${GREEN}could not detect shell, please manually add ${RED}$FORGE_DIR${GREEN} to your ${RED}PATH${GREEN} variable!${NC}
+    exit 1
 esac
 
 # Only add the forgeup directory to profile if it isn't in path
@@ -83,5 +90,5 @@ fi
 
 # Source the updated profile if we are in bash
 if [[ "$SHELL" == *"bash"* ]]; then
-   source $PROFILE
+    source $PROFILE
 fi

--- a/install
+++ b/install
@@ -17,7 +17,7 @@ NC="\033[0m"
 if ! command -v cargo &> /dev/null
 then
     echo -e ${RED}Error: ${GREEN}you do not have ${RED}cargo${GREEN}, please install it before using ${RED}forgeup${GREEN}!${NC}
-    exit
+    exit 1
 fi
 
 if [[ "$1" == *foundry* || "$1" == *dapptools-rs*  ]]
@@ -66,7 +66,7 @@ mkdir -p $FORGE_DIR
 echo "$FORGEUP" > $BINARY
 chmod +x $BINARY
 
-# Store the correct profile file (e.g. .profile for bash or .zshrc for ZSH)
+# Store the correct profile file (i.e. .profile for bash or .zshrc for ZSH)
 case $SHELL in
 */zsh) 
     echo -e ${GREEN}Detected your preferred shell is ${RED}zsh${GREEN}, adding ${RED}forgeup${GREEN} to ${RED}.zshrc${GREEN}. Please run ${RED}source \~/.zshrc${GREEN} after this script runs, or start a new terminal session to use ${RED}forgeup${GREEN}.${NC}

--- a/install
+++ b/install
@@ -68,14 +68,13 @@ chmod +x $BINARY
 
 # Store the correct profile file (i.e. .profile for bash or .zshrc for ZSH)
 case $SHELL in
-*/zsh) 
-    echo -e ${GREEN}Detected your preferred shell is ${RED}zsh${GREEN}, adding ${RED}forgeup${GREEN} to ${RED}.zshrc${GREEN}. Please run ${RED}source \~/.zshrc${GREEN} after this script runs, or start a new terminal session to use ${RED}forgeup${GREEN}.${NC}
+*/zsh)
     PROFILE=$HOME/.zshrc
+    PREF_SHELL=zsh
     ;;
 */bash)
-    echo -e ${GREEN}Detected your preferred shell is ${RED}bash${GREEN}, adding ${RED}forgeup${GREEN} to ${RED}.profile${GREEN}.
     PROFILE=$HOME/.profile
-    source $PROFILE
+    PREF_SHELL=bash
     ;;
 *)
     echo -e ${RED}Error: ${GREEN}could not detect shell, please manually add ${RED}$FORGE_DIR${GREEN} to your ${RED}PATH${GREEN} variable!${NC}
@@ -84,11 +83,8 @@ esac
 
 # Only add the forgeup directory to profile if it isn't in path
 if [[ ":$PATH:" != *":$HOME/.forgeup:"* ]]; then
-    # Add the forgeup directory to the path and source it
+    # Add the forgeup directory to the path and ensure the old PATH variables remain
     echo "export PATH=\$PATH:$FORGE_DIR" >> $PROFILE
 fi
 
-# Source the updated profile if we are in bash
-if [[ "$SHELL" == *"bash"* ]]; then
-    source $PROFILE
-fi
+echo -e ${GREEN}Detected your preferred shell is ${RED}${PREF_SHELL}${GREEN}, added ${RED}forgeup${GREEN} to PATH. Please run ${RED}source ${PROFILE}${GREEN} after this script runs, or start a new terminal session to use ${RED}forgeup${GREEN}.${NC}

--- a/install
+++ b/install
@@ -85,7 +85,7 @@ esac
 # Only add the forgeup directory to profile if it isn't in path
 if [[ ":$PATH:" != *":$HOME/.forgeup:"* ]]; then
     # Add the forgeup directory to the path and source it
-    echo "export PATH=$PATH:$FORGE_DIR" >> $PROFILE
+    echo "export PATH=\$PATH:$FORGE_DIR" >> $PROFILE
 fi
 
 # Source the updated profile if we are in bash

--- a/install
+++ b/install
@@ -60,14 +60,28 @@ mkdir -p $FORGE_DIR
 echo "$FORGEUP" > $BINARY
 chmod +x $BINARY
 
-# Source the profile to make sure we have an up-to-date PATH
-source $HOME/.profile
+# Store the correct profile file (e.g. .profile for bash or .zshrc for ZSH)
+case $SHELL in
+*/zsh) 
+   echo "Detected your preferred shell is ZSH, adding forgeup to '.zshrc'. Please run 'source ~/.zshrc' after this script runs, or start a new terminal session to use forgeup."
+   PROFILE=$HOME/.zshrc
+   ;;
+*/bash)
+   PROFILE=$HOME/.profile
+   source $PROFILE
+   ;;
+*)
+   echo "Error: could not detect shell, please manually add $FORGE_DIR to your PATH variable!"
+   exit 1
+esac
 
 # Only add the forgeup directory to profile if it isn't in path
 if [[ ":$PATH:" != *":$HOME/.forgeup:"* ]]; then
     # Add the forgeup directory to the path and source it
-    echo "export PATH=$PATH:$FORGE_DIR" >> $HOME/.profile
+    echo "export PATH=$PATH:$FORGE_DIR" >> $PROFILE
 fi
 
-# Source the updated profile
-source $HOME/.profile
+# Source the updated profile if we are in bash
+if [[ "$SHELL" == *"bash"* ]]; then
+   source $PROFILE
+fi


### PR DESCRIPTION
I personally use zsh instead of bash. This meant I got an error in L64 of the original `install` script as zsh uses a `.zshrc` file instead of a `.profile` file in $HOME.

This PR:
- adds initial shell detection (might be helpful in future)
- supports `.zshrc` files
- and also, because it affected me too, checks if `cargo` is installed before `forgeup` tries to run

Now my forge journey continues. :) 